### PR TITLE
Fix issue for OTP 25

### DIFF
--- a/lib/distillery/releases/assembler.ex
+++ b/lib/distillery/releases/assembler.ex
@@ -860,7 +860,7 @@ defmodule Distillery.Releases.Assembler do
     # no work around for this
     old_cwd = File.cwd!()
     File.cd!(output_dir)
-    :ok = :release_handler.create_RELEASES('./', 'releases', '#{relfile}', [])
+    :ok = :release_handler.create_RELEASES('./', Path.join([File.cwd!(), 'releases']), '#{relfile}', [])
     File.cd!(old_cwd)
     :ok
   end


### PR DESCRIPTION
### Summary of changes

Inspired by the solution provided into https://github.com/bitwalker/distillery/issues/744 
But I slightly modified it, so the `Root` parameter of `create_RELEASES` is actually `'./'`.
So we could potentially move the release file to another folder.