### PR TITLE
Fix issue for libraries with lib folder in priv like exla

### DIFF
--- a/lib/distillery/releases/archiver.ex
+++ b/lib/distillery/releases/archiver.ex
@@ -78,7 +78,7 @@ defmodule Distillery.Releases.Archiver do
 
     opts = [
       :silent,
-      {:path, ['#{Path.join([release.profile.output_dir, "lib", "*", "ebin"])}']},
+      {:path, ['#{Path.join([release.profile.output_dir, "lib", "*"])}']},
       {:dirs, included_dirs},
       {:outdir, '#{Path.dirname(archive_path)}'} | erts_opt
     ]

--- a/lib/distillery/releases/assembler.ex
+++ b/lib/distillery/releases/assembler.ex
@@ -860,7 +860,15 @@ defmodule Distillery.Releases.Assembler do
     # no work around for this
     old_cwd = File.cwd!()
     File.cd!(output_dir)
-    :ok = :release_handler.create_RELEASES('./', Path.join([File.cwd!(), 'releases']), '#{relfile}', [])
+
+    :ok =
+      :release_handler.create_RELEASES(
+        File.cwd!(),
+        Path.join([File.cwd!(), 'releases']),
+        '#{relfile}',
+        []
+      )
+
     File.cd!(old_cwd)
     :ok
   end
@@ -992,6 +1000,7 @@ defmodule Distillery.Releases.Assembler do
             "    this setting will prevent you from doing so without a rolling restart.\n" <>
             "    You may ignore this warning if you have no plans to use hot upgrades."
         )
+
         Shell.debug("Stripping release (#{path})")
 
         case :beam_lib.strip_release(String.to_charlist(path)) do


### PR DESCRIPTION
fix for including libraries containing lib folder inside priv that can contains additional header files or so files (in the case of EXLA libraries) in tarball generation.

this fix was tested with OTP 25.
